### PR TITLE
fix: 🐞  homebrewのインストール修正

### DIFF
--- a/setup.command
+++ b/setup.command
@@ -7,6 +7,23 @@ xcode-select --install
 
 # Homebrew
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+#書き込み対象フォルダを/Users/ユーザー名/.zshrcに設定
+USER_NAME=$(whoami)
+ARCH=$(uname -m)
+TARGET=/Users/${USER_NAME}/.zshrc
+
+#homebrewのパス設定を追記
+if [[ $ARCH == arm64 ]]; then
+    echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> ${TARGET}
+	eval $(/opt/homebrew/bin/brew shellenv)
+elif [[ $ARCH == x86_64 ]]; then
+    echo 'eval "$(/usr/local/bin/brew shellenv)"' >> ${TARGET}
+	eval $(/usr/local/bin/brew shellenv)
+fi
+#設定の再読み込み
+source ~/.zshrc
+
 brew update
 
 # Homebrew自動アップデート


### PR DESCRIPTION
CPUアーキテクチャによってhomebrewのインストール先が変化するため、アーキテクチャをもとにhomebrewのパスを設定ファイルに書き込む。